### PR TITLE
Implement Admin Mode with teacher login and protected registration

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -5,7 +5,8 @@ A super simple FastAPI application that allows students to view and sign up for 
 ## Features
 
 - View all available extracurricular activities
-- Sign up for activities
+- Teacher-only sign up/unregister for activities
+- Teacher login/logout with credentials stored in `teachers.json`
 
 ## Getting Started
 
@@ -30,7 +31,19 @@ A super simple FastAPI application that allows students to view and sign up for 
 | Method | Endpoint                                                          | Description                                                         |
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
-| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up student for an activity (teacher token required)           |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Unregister student from activity (teacher token required)      |
+| POST   | `/auth/login`                                                     | Teacher login (`username`, `password`)                              |
+| GET    | `/auth/status`                                                    | Validate current teacher token                                      |
+| POST   | `/auth/logout`                                                    | Logout teacher session                                              |
+
+## Admin Mode
+
+- The UI includes a teacher icon in the top-right corner.
+- Logged-out users can only view activities and participants.
+- Logged-in teachers can register or unregister students.
+
+Default demo credentials are defined in `teachers.json`.
 
 ## Data Model
 

--- a/src/app.py
+++ b/src/app.py
@@ -5,19 +5,45 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Header
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
 import os
+import json
+import secrets
 from pathlib import Path
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
 
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
 # Mount the static files directory
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+# Store temporary auth sessions in memory while the server is running.
+admin_sessions = {}
+
+
+def load_teachers():
+    teachers_file = current_dir / "teachers.json"
+    if not teachers_file.exists():
+        return {}
+
+    with open(teachers_file, "r", encoding="utf-8") as file:
+        payload = json.load(file)
+
+    teachers = payload.get("teachers", [])
+    return {teacher["username"]: teacher["password"] for teacher in teachers}
+
+
+teachers = load_teachers()
 
 # In-memory activity database
 activities = {
@@ -88,9 +114,51 @@ def get_activities():
     return activities
 
 
+@app.post("/auth/login")
+def admin_login(payload: LoginRequest):
+    expected_password = teachers.get(payload.username)
+
+    if not expected_password or payload.password != expected_password:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    token = secrets.token_urlsafe(24)
+    admin_sessions[token] = payload.username
+    return {"token": token, "username": payload.username}
+
+
+@app.get("/auth/status")
+def auth_status(x_admin_token: str | None = Header(default=None)):
+    if not x_admin_token or x_admin_token not in admin_sessions:
+        return {"authenticated": False}
+
+    return {
+        "authenticated": True,
+        "username": admin_sessions[x_admin_token]
+    }
+
+
+@app.post("/auth/logout")
+def admin_logout(x_admin_token: str | None = Header(default=None)):
+    if x_admin_token in admin_sessions:
+        del admin_sessions[x_admin_token]
+
+    return {"message": "Logged out"}
+
+
+def require_admin_token(x_admin_token: str | None):
+    if not x_admin_token or x_admin_token not in admin_sessions:
+        raise HTTPException(
+            status_code=403,
+            detail="Only logged-in teachers can register or unregister students"
+        )
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str,
+                        x_admin_token: str | None = Header(default=None)):
     """Sign up a student for an activity"""
+    require_admin_token(x_admin_token)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +179,11 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str,
+                             x_admin_token: str | None = Header(default=None)):
     """Unregister a student from an activity"""
+    require_admin_token(x_admin_token)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,68 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const adminToggle = document.getElementById("admin-toggle");
+  const adminPanel = document.getElementById("admin-panel");
+  const showLogin = document.getElementById("show-login");
+  const loginForm = document.getElementById("login-form");
+  const logoutBtn = document.getElementById("logout-btn");
+  const adminStatus = document.getElementById("admin-status");
+
+  let adminToken = localStorage.getItem("adminToken") || "";
+  let adminUsername = localStorage.getItem("adminUsername") || "";
+
+  function updateAdminUi() {
+    const isLoggedIn = Boolean(adminToken);
+
+    signupForm.querySelector("button[type='submit']").disabled = !isLoggedIn;
+    signupForm.querySelectorAll("input, select").forEach((field) => {
+      field.disabled = !isLoggedIn;
+    });
+
+    document.querySelectorAll(".delete-btn").forEach((button) => {
+      button.disabled = !isLoggedIn;
+      button.title = isLoggedIn
+        ? "Unregister student"
+        : "Teacher login required";
+    });
+
+    showLogin.classList.toggle("hidden", isLoggedIn);
+    loginForm.classList.toggle("hidden", isLoggedIn);
+    logoutBtn.classList.toggle("hidden", !isLoggedIn);
+    adminStatus.textContent = isLoggedIn
+      ? `Teacher mode: ${adminUsername}`
+      : "Viewing mode (students)";
+  }
+
+  async function restoreAuthState() {
+    if (!adminToken) {
+      updateAdminUi();
+      return;
+    }
+
+    try {
+      const response = await fetch("/auth/status", {
+        headers: {
+          "X-Admin-Token": adminToken,
+        },
+      });
+
+      const result = await response.json();
+      if (!result.authenticated) {
+        adminToken = "";
+        adminUsername = "";
+        localStorage.removeItem("adminToken");
+        localStorage.removeItem("adminUsername");
+      }
+    } catch (error) {
+      adminToken = "";
+      adminUsername = "";
+      localStorage.removeItem("adminToken");
+      localStorage.removeItem("adminUsername");
+    }
+
+    updateAdminUi();
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -60,6 +122,8 @@ document.addEventListener("DOMContentLoaded", () => {
       document.querySelectorAll(".delete-btn").forEach((button) => {
         button.addEventListener("click", handleUnregister);
       });
+
+      updateAdminUi();
     } catch (error) {
       activitiesList.innerHTML =
         "<p>Failed to load activities. Please try again later.</p>";
@@ -69,6 +133,13 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Handle unregister functionality
   async function handleUnregister(event) {
+    if (!adminToken) {
+      messageDiv.textContent = "Teacher login required to unregister students.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      return;
+    }
+
     const button = event.target;
     const activity = button.getAttribute("data-activity");
     const email = button.getAttribute("data-email");
@@ -80,6 +151,9 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: {
+            "X-Admin-Token": adminToken,
+          },
         }
       );
 
@@ -114,6 +188,13 @@ document.addEventListener("DOMContentLoaded", () => {
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
 
+    if (!adminToken) {
+      messageDiv.textContent = "Teacher login required to register students.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      return;
+    }
+
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
 
@@ -124,6 +205,9 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: {
+            "X-Admin-Token": adminToken,
+          },
         }
       );
 
@@ -155,6 +239,77 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
+  adminToggle.addEventListener("click", () => {
+    adminPanel.classList.toggle("hidden");
+  });
+
+  showLogin.addEventListener("click", () => {
+    loginForm.classList.toggle("hidden");
+  });
+
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const username = document.getElementById("username").value.trim();
+    const password = document.getElementById("password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+      if (!response.ok) {
+        messageDiv.textContent = result.detail || "Login failed";
+        messageDiv.className = "error";
+        messageDiv.classList.remove("hidden");
+        return;
+      }
+
+      adminToken = result.token;
+      adminUsername = result.username;
+      localStorage.setItem("adminToken", adminToken);
+      localStorage.setItem("adminUsername", adminUsername);
+      updateAdminUi();
+
+      messageDiv.textContent = `Logged in as ${adminUsername}`;
+      messageDiv.className = "success";
+      messageDiv.classList.remove("hidden");
+      loginForm.reset();
+    } catch (error) {
+      messageDiv.textContent = "Failed to login. Please try again.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+    }
+  });
+
+  logoutBtn.addEventListener("click", async () => {
+    try {
+      await fetch("/auth/logout", {
+        method: "POST",
+        headers: {
+          "X-Admin-Token": adminToken,
+        },
+      });
+    } catch (error) {
+      // No-op: local logout still applies if request fails.
+    }
+
+    adminToken = "";
+    adminUsername = "";
+    localStorage.removeItem("adminToken");
+    localStorage.removeItem("adminUsername");
+    updateAdminUi();
+
+    messageDiv.textContent = "Logged out";
+    messageDiv.className = "info";
+    messageDiv.classList.remove("hidden");
+  });
+
   // Initialize app
+  restoreAuthState();
   fetchActivities();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,6 +8,27 @@
   </head>
   <body>
     <header>
+      <div class="admin-controls">
+        <button id="admin-toggle" class="icon-button" aria-label="Teacher login">
+          <span aria-hidden="true">👤</span>
+        </button>
+        <div id="admin-panel" class="admin-panel hidden">
+          <button id="show-login" type="button">Teacher Login</button>
+          <form id="login-form" class="hidden">
+            <div class="form-group">
+              <label for="username">Username:</label>
+              <input type="text" id="username" required />
+            </div>
+            <div class="form-group">
+              <label for="password">Password:</label>
+              <input type="password" id="password" required />
+            </div>
+            <button type="submit">Sign In</button>
+          </form>
+          <button id="logout-btn" type="button" class="hidden">Logout</button>
+          <p id="admin-status" class="admin-status">Viewing mode (students)</p>
+        </div>
+      </div>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
     </header>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,12 +16,65 @@ body {
 }
 
 header {
+  position: relative;
   text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+}
+
+.admin-controls {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.icon-button {
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border-radius: 999px;
+  font-size: 22px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #ffffff;
+  color: #1a237e;
+}
+
+.icon-button:hover {
+  background-color: #e8eaf6;
+}
+
+.admin-panel {
+  width: min(320px, calc(100vw - 30px));
+  background: #ffffff;
+  color: #111;
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  padding: 12px;
+  text-align: left;
+}
+
+.admin-panel .form-group {
+  margin-bottom: 10px;
+}
+
+.admin-panel button {
+  margin-top: 6px;
+}
+
+.admin-status {
+  margin-top: 10px;
+  font-size: 14px;
+  color: #37474f;
 }
 
 header h1 {
@@ -119,6 +172,12 @@ section h3 {
   padding: 2px 5px;
   transition: all 0.2s;
   border-radius: 3px;
+}
+
+.delete-btn:disabled,
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .delete-btn:hover {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,12 @@
+{
+  "teachers": [
+    {
+      "username": "teacher1",
+      "password": "mergington123"
+    },
+    {
+      "username": "teacher2",
+      "password": "schoolclubs456"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
This PR implements Issue #5 (Admin Mode).

## What changed
- Added teacher login/logout endpoints and auth status checks.
- Added token-based protection so only logged-in teachers can register/unregister students.
- Added `teachers.json` for teacher credentials (as requested in issue).
- Added top-right user icon + login panel in frontend.
- Disabled registration/unregistration actions for non-logged-in users while keeping participant visibility.
- Updated README with Admin Mode and new API endpoints.

## Notes
- This keeps storage in-memory for sessions, aligned with current app architecture.
- Demo teacher credentials are in `src/teachers.json`.

Closes #5